### PR TITLE
Closes #13 performance improvements, add more benchmarks, add intersectHash method

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,42 @@ func main() {
 ```
 
 ## Benchmarks
+Benchmarks are compared with the same methods written using pure go.  
+The results for MacBook Air M1, MacOS 12.0.1, Go 1.18.1 are:
 ```
-BenchmarkStdLibSortFunc-10    	  743384	      1434 ns/op	    1064 B/op	       8 allocs/op
-BenchmarkSortFuncShort-10     	  612254	      1946 ns/op	    2016 B/op	      12 allocs/op
-BenchmarkStdLibSort-10        	  785678	      1477 ns/op	    1032 B/op	       7 allocs/op
-BenchmarkSortShort-10         	  692116	      1672 ns/op	    2016 B/op	      12 allocs/op
+goos: darwin
+goarch: arm64
+
+BenchmarkStdLibSortFunc-8   	  106189	      9576 ns/op	    4152 B/op	       3 allocs/op
+BenchmarkSortFuncShort-8    	   96883	     11896 ns/op	    8192 B/op	       2 allocs/op
+BenchmarkStdLibSort-8       	  125802	      9386 ns/op	    4120 B/op	       2 allocs/op
+BenchmarkSortShort-8        	  120718	      9696 ns/op	    8192 B/op	       2 allocs/op
+
+BenchmarkReverse/strings_237_pure-8         	 2007199	       613.9 ns/op	    4096 B/op	       1 allocs/op
+BenchmarkReverse/strings_237-8              	 1950008	       616.5 ns/op	    4096 B/op	       1 allocs/op
+BenchmarkReverse/strings_7584_pure-8        	   68170	     17541 ns/op	  122880 B/op	       1 allocs/op
+BenchmarkReverse/strings_7584-8             	   68252	     17510 ns/op	  122880 B/op	       1 allocs/op
+BenchmarkReverse/int64_70_pure-8            	14714168	        80.83 ns/op	     576 B/op	       1 allocs/op
+BenchmarkReverse/int64_70-8                 	14874696	        81.01 ns/op	     576 B/op	       1 allocs/op
+
+BenchmarkConcat/strings_6x237_pure-8        	  442657	      2474 ns/op	   24576 B/op	       1 allocs/op
+BenchmarkConcat/strings_6x237-8             	  486512	      2468 ns/op	   24576 B/op	       1 allocs/op
+BenchmarkConcat/int64_6x70_pure-8           	 4153170	       292.9 ns/op	    3456 B/op	       1 allocs/op
+BenchmarkConcat/int64_6x70-8                	 4092565	       288.2 ns/op	    3456 B/op	       1 allocs/op
+
+BenchmarkFilter/strings_237_(len>5)_pure-8  	 1285369	       918.2 ns/op	    4096 B/op	       1 allocs/op
+BenchmarkFilter/strings_237_(len>5)-8       	 1277200	       933.4 ns/op	    4096 B/op	       1 allocs/op
+BenchmarkFilter/int64_70_(val>40)_pure-8    	 6271178	       194.5 ns/op	     576 B/op	       1 allocs/op
+BenchmarkFilter/int64_70_(val>40)-8         	 6183364	       194.4 ns/op	     576 B/op	       1 allocs/op
+
+BenchmarkMap/strings_237_replace_a_b_pure-8 	  221564	      5347 ns/op	    4768 B/op	      99 allocs/op
+BenchmarkMap/strings_237_replace_a_b-8      	  219157	      5379 ns/op	    4768 B/op	      99 allocs/op
+BenchmarkMap/int64_237_*5_pure-8            	 9189534	       135.1 ns/op	     576 B/op	       1 allocs/op
+BenchmarkMap/int64_237_*5-8                 	 8258142	       139.0 ns/op	     576 B/op	       1 allocs/op
+
+BenchmarkIntersect/int64_70-46-47_pure-8    	  224929	      5325 ns/op	     576 B/op	       1 allocs/op
+BenchmarkIntersect/int64_70-46-47-8         	  220717	      5423 ns/op	     576 B/op	       1 allocs/op
+BenchmarkIntersect/int64_70-46-47_hash-8    	  208978	      5653 ns/op	    2417 B/op	       4 allocs/op
 ```
 
 ## Contribute

--- a/slices.go
+++ b/slices.go
@@ -2,9 +2,9 @@ package slices
 
 // Clone creates a clone slice and returns it.
 func Clone[T any](s []T) []T {
-	var c []T
+	c := make([]T, len(s))
 	for i := range s {
-		c = append(c, s[i])
+		c[i] = s[i]
 	}
 	return c
 }
@@ -18,9 +18,9 @@ func Append[T any](s []T, item ...T) []T {
 // Reverse creates a slice that is the reverse of the provided slice
 // and returns it. The given slice is not changed.
 func Reverse[T any](s []T) []T {
-	var res []T
+	res := make([]T, len(s))
 	for i := 0; i < len(s); i++ {
-		res = Append(res, s[len(s)-1-i])
+		res[i] = s[len(s)-1-i]
 	}
 	return res
 }
@@ -37,10 +37,16 @@ func Splice[T any](s []T, index int, cnt int, item ...T) []T {
 // Concat combines the contents of all the given slices. The given
 // slices are not changed.
 func Concat[T any](s ...[]T) []T {
-	var output []T
+	totalLen := 0
 	for i := range s {
-		output = Append(output, s[i]...)
+		totalLen += len(s[i])
 	}
+
+	output := make([]T, 0, totalLen)
+	for i := range s {
+		output = append(output, s[i]...)
+	}
+
 	return output
 }
 
@@ -191,7 +197,7 @@ func Filter[T any](s []T, test func(item T) bool) []T {
 	n := make([]T, 0, len(s))
 	for i := range s {
 		if test(s[i]) {
-			n = Append(n, s[i])
+			n = append(n, s[i])
 		}
 	}
 	return n
@@ -201,9 +207,9 @@ func Filter[T any](s []T, test func(item T) bool) []T {
 // according to the given m function. The given slice is not
 // changed.
 func Map[T any, K any](s []T, m func(item T) K) []K {
-	var k []K
+	k := make([]K, len(s))
 	for i := range s {
-		k = Append(k, m(s[i]))
+		k[i] = m(s[i])
 	}
 	return k
 }
@@ -222,15 +228,52 @@ func Reduce[T any, K any](s []T, f func(prev K, cur T) K) K {
 // Intersection creates a new slice that contains the intersection of
 // all the given slices. The given slices are not changed.
 func Intersection[T Ordered](s ...[]T) []T {
-	var output []T
+	if len(s) == 0 {
+		return []T{}
+	}
+
+	output := make([]T, 0, len(s[0]))
 	for i := range s {
 		for j := range s[i] {
 			if !Contains(output, s[i][j]) && Every(s, func(item []T) bool { return Contains(item, s[i][j]) }) {
-				output = Append(output, s[i][j])
+				output = append(output, s[i][j])
 			}
 		}
 	}
 	return output
+}
+
+// Intersection creates a new slice that contains the intersection of
+// all the given slices using hash algorithm. The given slices are not changed.
+func IntersectionHash[T Ordered](s ...[]T) []T {
+	if len(s) == 0 {
+		return []T{}
+	}
+
+	mapLen := 0
+	for i := range s {
+		mapLen += len(s[i])
+	}
+
+	hash := make(map[T]int16, mapLen)
+
+	for i := range s {
+		for j := range s[i] {
+			c := hash[s[i][j]]
+			if c <= int16(i) {
+				hash[s[i][j]] = c + 1
+			}
+		}
+	}
+
+	result := make([]T, 0, len(s[0]))
+	for k := range hash {
+		if hash[k] >= int16(len(s)) {
+			result = append(result, k)
+		}
+	}
+
+	return result
 }
 
 // Union creates a new slice that contains the union of all the given
@@ -240,7 +283,7 @@ func Union[T Ordered](s ...[]T) []T {
 	for i := range s {
 		for j := range s[i] {
 			if !Contains(output, s[i][j]) {
-				output = Append(output, s[i][j])
+				output = append(output, s[i][j])
 			}
 		}
 	}

--- a/slices_test.go
+++ b/slices_test.go
@@ -1,6 +1,7 @@
 package slices_test
 
 import (
+	"fmt"
 	"reflect"
 	"sort"
 	"strings"
@@ -11,175 +12,139 @@ import (
 
 func TestPush(t *testing.T) {
 	s := []int{1}
-	s = slices.Append(s, 5)
+	got := slices.Append(s, 5)
 	want := []int{1, 5}
-	if !reflect.DeepEqual(s, want) {
-		t.Fatalf("want %v; got %v", want, s)
-	}
+	assertEqual(t, got, want)
 }
 
 func TestContainsTrue(t *testing.T) {
 	s := []int{1, 2, 3}
 	got := slices.Contains(s, 2)
 	want := true
-	if !reflect.DeepEqual(want, got) {
-		t.Fatalf("want %v; got %v", want, got)
-	}
+	assertEqual(t, got, want)
 }
 
 func TestContainsFalse(t *testing.T) {
 	s := []int{1, 2, 3}
 	got := slices.Contains(s, 4)
 	want := false
-	if !reflect.DeepEqual(want, got) {
-		t.Fatalf("want %v; got %v", want, got)
-	}
+	assertEqual(t, got, want)
 }
 
 func TestSpliceNoInserts(t *testing.T) {
 	s := []string{"foo", "bar", "baz"}
 	got := slices.Splice(s, 1, 1)
 	want := []string{"foo", "baz"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("want %v; got %v", want, got)
-	}
+	assertEqual(t, got, want)
 }
 
 func TestSpliceWithInserts(t *testing.T) {
 	s := []string{"foo", "bar", "baz"}
 	got := slices.Splice(s, 1, 1, "boo")
 	want := []string{"foo", "boo", "baz"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("want %v; got %v", want, got)
-	}
+	assertEqual(t, got, want)
 }
 
 func TestReverseEven(t *testing.T) {
 	s := []string{"foo", "bar"}
 	got := slices.Reverse(s)
 	want := []string{"bar", "foo"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("want %v; got %v", want, got)
-	}
+	assertEqual(t, got, want)
 }
 
 func TestReverseOdd(t *testing.T) {
 	s := []string{"foo", "bar", "baz"}
 	got := slices.Reverse(s)
 	want := []string{"baz", "bar", "foo"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("want %v; got %v", want, got)
-	}
+	assertEqual(t, got, want)
 }
 
 func TestUnshift(t *testing.T) {
 	s := []string{"foo"}
 	got := slices.Unshift(s, "bar")
 	want := []string{"bar", "foo"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("want %v; got %v", want, got)
-	}
+	assertEqual(t, got, want)
 }
 
 func TestFindFound(t *testing.T) {
 	s := []string{"foo"}
-	found := slices.Find(s, func(item string) bool {
+	got := slices.Find(s, func(item string) bool {
 		return item == "foo"
 	})
-	if found != "foo" {
-		t.Fatalf("wrong find %s", found)
-	}
+	want := "foo"
+	assertEqual(t, got, want)
 }
 
 func TestFindNotFound(t *testing.T) {
 	s := []string{"foo"}
-	found := slices.Find(s, func(item string) bool {
+	got := slices.Find(s, func(item string) bool {
 		return item == "bar"
 	})
-	if found != "" {
-		t.Fatalf("wrong find %s", found)
-	}
+	want := ""
+	assertEqual(t, got, want)
 }
 
 func TestFilter(t *testing.T) {
 	s := []string{"foo", "bar"}
-	ns := slices.Filter(s, func(item string) bool {
+	got := slices.Filter(s, func(item string) bool {
 		return strings.HasPrefix(item, "f")
 	})
-	if len(ns) != 1 {
-		t.Fatalf("wrong len %d", len(ns))
-	}
+	assertEqual(t, len(got), 1)
 }
 
 func TestMaxZeroValue(t *testing.T) {
 	s := []string{}
 	got := slices.Max(s)
 	want := ""
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("want %v; got %v", want, got)
-	}
+	assertEqual(t, got, want)
 }
 func TestMinZeroValue(t *testing.T) {
 	s := []string{}
 	got := slices.Min(s)
 	want := ""
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("want %v; got %v", want, got)
-	}
+	assertEqual(t, got, want)
 }
 
 func TestMax(t *testing.T) {
 	s := []int{2, 6, 1, 4, 3}
 	got := slices.Max(s)
 	want := 6
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("want %v; got %v", want, got)
-	}
+	assertEqual(t, got, want)
 }
 
 func TestMin(t *testing.T) {
 	s := []int{2, 6, 1, 4, 3}
 	got := slices.Min(s)
 	want := 1
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("want %v; got %v", want, got)
-	}
+	assertEqual(t, got, want)
 }
 
 func TestMaxFuncZeroValue(t *testing.T) {
 	s := []int{}
 	got := slices.MaxFunc(s, func(a, b int) bool { return a < b })
 	want := 0
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("want %v; got %v", want, got)
-	}
+	assertEqual(t, got, want)
 }
 
 func TestMinFuncZeroValue(t *testing.T) {
 	s := []int{}
 	got := slices.MinFunc(s, func(a, b int) bool { return a < b })
 	want := 0
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("want %v; got %v", want, got)
-	}
+	assertEqual(t, got, want)
 }
 
 func TestMaxFunc(t *testing.T) {
 	s := []int{2, 6, 1, 4, 3}
 	got := slices.MaxFunc(s, func(a, b int) bool { return a < b })
 	want := 6
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("want %v; got %v", want, got)
-	}
+	assertEqual(t, got, want)
 }
 
 func TestMinFunc(t *testing.T) {
 	s := []int{2, 6, 1, 4, 3}
 	got := slices.MinFunc(s, func(a, b int) bool { return a < b })
 	want := 1
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("want %v; got %v", want, got)
-	}
+	assertEqual(t, got, want)
 }
 
 func TestSomeTrue(t *testing.T) {
@@ -216,25 +181,23 @@ func TestMap(t *testing.T) {
 		return len(i)
 	})
 	want := []int{1, 2, 3}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("want %v; got %v", want, got)
-	}
+	assertEqual(t, got, want)
 }
 
 func TestReduce(t *testing.T) {
 	s := []string{"f", "ba", "baz"}
-	cnt := slices.Reduce(s, func(cnt int, i string) int {
+	got := slices.Reduce(s, func(cnt int, i string) int {
 		return cnt + len(i)
 	})
-	if cnt != 6 {
-		t.Fatalf("%d != %d", cnt, 6)
-	}
+	want := 6
+	assertEqual(t, got, want)
 }
 
-var unsorted = []string{"foo", "bar", "baz", "lorem", "ipsum", "donor", "sit", "alpha", "beta", "delta", "gamma", "omega", "epsilon", "mu", "nu", "lambda", "upsilon", "zeta", "eta", "rho", "psi", "iota", "apple", "banana", "pomegranate", "orange", "kiwi", "carrot", "broccoli"}
+var unsortedString = []string{"Mauris", "in", "luctus", "mi", "Suspendisse", "enim", "mi", "volutpat", "at", "urna", "ut", "condimentum", "feugiat", "lectus", "Nunc", "pulvinar", "arcu", "eget", "quam", "facilisis", "nec", "lobortis", "urna", "aliquet", "Vestibulum", "feugiat", "enim", "nec", "justo", "aliquam", "fringilla", "Fusce", "vitae", "ultrices", "orci", "Pellentesque", "consectetur", "ex", "quis", "fringilla", "finibus", "Nullam", "suscipit", "arcu", "suscipit", "vestibulum", "eros", "nec", "aliquet", "erat", "Pellentesque", "finibus", "sollicitudin", "libero", "sed", "lobortis", "Sed", "ut", "diam", "venenatis", "cursus", "velit", "non", "interdum", "lacus", "Mauris", "malesuada", "eros", "in", "dictum", "pellentesque", "ante", "tellus", "faucibus", "purus", "a", "ultricies", "sapien", "turpis", "nec", "sem", "Fusce", "sit", "amet", "aliquam", "turpis", "Phasellus", "id", "magna", "magna", "Morbi", "at", "erat", "est", "Pellentesque", "et", "porta", "loremSed", "fermentum", "metus", "at", "enim", "tempor", "auctor", "Phasellus", "hendrerit", "nunc", "sed", "cursus", "mattis", "sem", "mauris", "aliquet", "turpis", "ut", "gravida", "eros", "lacus", "non", "enim", "Quisque", "auctor", "turpis", "et", "nulla", "cursus", "sit", "amet", "blandit", "magna", "blandit", "In", "quis", "sodales", "ligula", "at", "aliquam", "lacus", "Duis", "dictum", "dapibus", "efficitur", "Sed", "sem", "tortor", "tincidunt", "vel", "sem", "ut", "suscipit", "porta", "mauris", "Mauris", "at", "nisl", "at", "odio", "cursus", "sollicitudin", "Etiam", "sit", "amet", "blandit", "ipsum", "Nullam", "et", "vehicula", "felis", "Integer", "sed", "elit", "ut", "ligula", "dignissim", "commodo", "Lorem", "ipsum", "dolor", "sit", "amet", "consectetur", "adipiscing", "elit", "Sed", "venenatis", "metus", "varius", "tristique", "auctor", "urna", "arcu", "pharetra", "quam", "ut", "consequat", "urna", "felis", "ut", "arcu", "Phasellus", "iaculis", "facilisis", "odio", "non", "finibus", "odio", "finibus", "vel", "Morbi", "risus", "quam", "laoreet", "sit", "amet", "maximus", "eu", "laoreet", "sit", "amet", "magna", "Interdum", "et", "malesuada", "fames", "ac", "ante", "ipsum", "primis", "in", "faucibus", "Etiam", "quis", "lacinia", "purus", "ut", "interdum", "diam"}
+var unsortedInt64 = []int64{53, 88, 23, 25, 64, 71, 7, 83, 17, 33, 12, 31, 69, 14, 90, 77, 22, 2, 96, 10, 45, 47, 35, 89, 49, 42, 76, 32, 15, 75, 62, 79, 72, 27, 57, 5, 59, 30, 61, 60, 9, 67, 40, 85, 46, 73, 34, 65, 36, 82, 20, 4, 3, 13, 58, 99, 24, 1, 51, 78, 100, 86, 28, 26, 68, 41, 43, 91, 18, 55}
 
 func TestSortFunc(t *testing.T) {
-	s := slices.Clone(unsorted)
+	s := slices.Clone(unsortedString)
 	got := slices.SortFunc(s, func(a string, b string) bool {
 		return a < b
 	})
@@ -242,29 +205,47 @@ func TestSortFunc(t *testing.T) {
 	sort.Slice(want, func(i, j int) bool {
 		return want[i] < want[j]
 	})
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("want %v; got %v", want, got)
-	}
+	assertEqual(t, got, want)
 }
 
 func TestSort(t *testing.T) {
-	s := slices.Clone(unsorted)
+	s := slices.Clone(unsortedString)
 	got := slices.Sort(s)
 	want := slices.Clone(s)
 	sort.Strings(want)
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("want %v; got %v", want, got)
-	}
+	assertEqual(t, got, want)
 }
 
 func TestIntersection(t *testing.T) {
-	a := []string{"foo", "bar"}
-	b := []string{"bar", "baz"}
-	want := []string{"bar"}
-	got := slices.Intersection(a, b)
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("want %v; got %v", want, got)
-	}
+	t.Run("common", func(t *testing.T) {
+		a := []string{"foo", "bar"}
+		b := []string{"bar", "baz"}
+		want := []string{"bar"}
+		got := slices.Intersection(a, b)
+		assertEqual(t, got, want)
+	})
+
+	t.Run("empty slice", func(t *testing.T) {
+		var s [][]string
+		got := slices.Intersection(s...)
+		assertEqual(t, got, []string{})
+	})
+}
+
+func TestIntersectionHash(t *testing.T) {
+	t.Run("common", func(t *testing.T) {
+		a := []string{"foo", "bar", "baz"}
+		b := []string{"bar", "baz"}
+		want := []string{"bar", "baz"}
+		got := slices.Sort(slices.IntersectionHash(a, b))
+		assertEqual(t, got, want)
+	})
+
+	t.Run("empty slice", func(t *testing.T) {
+		var s [][]string
+		got := slices.IntersectionHash(s...)
+		assertEqual(t, got, []string{})
+	})
 }
 
 func TestUnion(t *testing.T) {
@@ -272,14 +253,12 @@ func TestUnion(t *testing.T) {
 	b := []string{"bar", "baz"}
 	want := slices.Sort([]string{"foo", "bar", "baz"})
 	got := slices.Sort(slices.Union(a, b))
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("want %v; got %v", want, got)
-	}
+	assertEqual(t, got, want)
 }
 
 func BenchmarkStdLibSortFunc(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		s := slices.Clone(unsorted)
+		s := slices.Clone(unsortedString)
 		sort.Slice(s, func(i, j int) bool {
 			return s[i] < s[j]
 		})
@@ -288,7 +267,7 @@ func BenchmarkStdLibSortFunc(b *testing.B) {
 
 func BenchmarkSortFuncShort(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		s := slices.Clone(unsorted)
+		s := slices.Clone(unsortedString)
 		_ = slices.SortFunc(s, func(a string, b string) bool {
 			return a < b
 		})
@@ -297,14 +276,429 @@ func BenchmarkSortFuncShort(b *testing.B) {
 
 func BenchmarkStdLibSort(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		s := slices.Clone(unsorted)
+		s := slices.Clone(unsortedString)
 		sort.Strings(s)
 	}
 }
 
 func BenchmarkSortShort(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		s := slices.Clone(unsorted)
+		s := slices.Clone(unsortedString)
 		_ = slices.Sort(s)
+	}
+}
+
+func BenchmarkReverse(b *testing.B) {
+	s0 := slices.Clone(unsortedString)
+	b.Run(fmt.Sprintf("strings_%d_pure", len(s0)), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = reverseStringsPure(s0)
+		}
+	})
+
+	s1 := slices.Clone(unsortedString)
+	b.Run(fmt.Sprintf("strings_%d", len(s1)), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = slices.Reverse(s1)
+		}
+	})
+
+	sl0 := slices.Clone(unsortedString)
+	for i := 0; i < 5; i++ {
+		sl0 = append(sl0, sl0...)
+	}
+	b.Run(fmt.Sprintf("strings_%d_pure", len(sl0)), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = reverseStringsPure(sl0)
+		}
+	})
+
+	sl1 := slices.Clone(unsortedString)
+	for i := 0; i < 5; i++ {
+		sl1 = append(sl1, sl1...)
+	}
+
+	b.Run(fmt.Sprintf("strings_%d", len(sl1)), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = slices.Reverse(sl1)
+		}
+	})
+
+	i0 := slices.Clone(unsortedInt64)
+	b.Run(fmt.Sprintf("int64_%d_pure", len(i0)), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = reverseInt64sPure(i0)
+		}
+	})
+
+	i1 := slices.Clone(unsortedInt64)
+	b.Run(fmt.Sprintf("int64_%d", len(i1)), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = slices.Reverse(i1)
+		}
+	})
+}
+
+func reverseStringsPure(v []string) []string {
+	reversed := make([]string, len(v))
+	for j := range v {
+		reversed[j] = v[len(v)-j-1]
+	}
+	return reversed
+}
+
+func reverseInt64sPure(v []int64) []int64 {
+	reversed := make([]int64, len(v))
+	for j := range v {
+		reversed[j] = v[len(v)-j-1]
+	}
+
+	return reversed
+}
+
+func BenchmarkConcat(b *testing.B) {
+	n := 6
+	s0 := make([][]string, n)
+	for i := 0; i < n; i++ {
+		s0[i] = slices.Clone(unsortedString)
+	}
+
+	b.Run(fmt.Sprintf("strings_%dx%d_pure", n, len(unsortedString)), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = concanStringsPure(s0[0], s0[1], s0[2], s0[3], s0[4], s0[5])
+		}
+	})
+
+	s1 := make([][]string, n)
+	for i := 0; i < n; i++ {
+		s1[i] = slices.Clone(unsortedString)
+	}
+
+	b.Run(fmt.Sprintf("strings_%dx%d", n, len(unsortedString)), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = slices.Concat(s1[0], s1[1], s1[2], s1[3], s1[4], s1[5])
+		}
+	})
+
+	i0 := make([][]int64, n)
+	for i := 0; i < n; i++ {
+		i0[i] = slices.Clone(unsortedInt64)
+	}
+	b.Run(fmt.Sprintf("int64_%dx%d_pure", n, len(unsortedInt64)), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = concanInt64Pure(i0[0], i0[1], i0[2], i0[3], i0[4], i0[5])
+		}
+	})
+
+	i1 := make([][]int64, n)
+	for i := 0; i < n; i++ {
+		i1[i] = slices.Clone(unsortedInt64)
+	}
+	b.Run(fmt.Sprintf("int64_%dx%d", n, len(unsortedInt64)), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = slices.Concat(i1[0], i1[1], i1[2], i1[3], i1[4], i1[5])
+		}
+	})
+}
+
+func concanInt64Pure(v ...[]int64) []int64 {
+	totalLen := 0
+	for j := range v {
+		totalLen += len(v[j])
+	}
+
+	result := make([]int64, 0, totalLen)
+	for j := range v {
+		result = append(result, v[j]...)
+	}
+
+	return result
+}
+
+func concanStringsPure(v ...[]string) []string {
+	totalLen := 0
+	for j := range v {
+		totalLen += len(v[j])
+	}
+
+	result := make([]string, 0, totalLen)
+	for j := range v {
+		result = append(result, v[j]...)
+	}
+
+	return result
+}
+
+func BenchmarkFilter(b *testing.B) {
+	sn := 5
+	sFunc := func(v string) bool {
+		return len(v) > sn
+	}
+	s0 := slices.Clone(unsortedString)
+	b.Run(fmt.Sprintf("strings_%d_(len>%d)_pure", len(s0), sn), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = filterStringsPure(s0, sFunc)
+		}
+	})
+
+	s1 := slices.Clone(unsortedString)
+	b.Run(fmt.Sprintf("strings_%d_(len>%d)", len(s1), sn), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = slices.Filter(s0, sFunc)
+		}
+	})
+
+	in := int64(40)
+	iFunc := func(v int64) bool {
+		return v > in
+	}
+	i0 := slices.Clone(unsortedInt64)
+	b.Run(fmt.Sprintf("int64_%d_(val>%d)_pure", len(i0), in), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = filterInt64Pure(i0, iFunc)
+		}
+	})
+
+	i1 := slices.Clone(unsortedInt64)
+	b.Run(fmt.Sprintf("int64_%d_(val>%d)", len(i1), in), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = slices.Filter(i1, iFunc)
+		}
+	})
+}
+
+func filterStringsPure(v []string, f func(string) bool) []string {
+	result := make([]string, 0, len(v))
+	for i := range v {
+		if f(v[i]) {
+			result = append(result, v[i])
+		}
+	}
+
+	return result
+}
+
+func filterInt64Pure(v []int64, f func(int64) bool) []int64 {
+	result := make([]int64, 0, len(v))
+	for i := range v {
+		if f(v[i]) {
+			result = append(result, v[i])
+		}
+	}
+
+	return result
+}
+
+func BenchmarkMap(b *testing.B) {
+	sFunc := func(s string) string {
+		return strings.ReplaceAll(s, "a", "b")
+	}
+	s0 := slices.Clone(unsortedString)
+	b.Run(fmt.Sprintf("strings_%d_replace_a_b_pure", len(s0)), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = mapStringsPure(s0, sFunc)
+		}
+	})
+
+	s1 := slices.Clone(unsortedString)
+	b.Run(fmt.Sprintf("strings_%d_replace_a_b", len(s1)), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = slices.Map(s1, sFunc)
+		}
+	})
+
+	in := int64(5)
+	iFunc := func(i int64) int64 {
+		return i * in
+	}
+	i0 := slices.Clone(unsortedInt64)
+	b.Run(fmt.Sprintf("int64_%d_*%d_pure", len(s0), in), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = mapInt64Pure(i0, iFunc)
+		}
+	})
+
+	i1 := slices.Clone(unsortedInt64)
+	b.Run(fmt.Sprintf("int64_%d_*%d", len(s1), in), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = slices.Map(i1, iFunc)
+		}
+	})
+}
+
+func mapStringsPure(v []string, f func(string) string) []string {
+	result := make([]string, len(v))
+	for j := range v {
+		result[j] = f(v[j])
+	}
+
+	return result
+}
+
+func mapInt64Pure(v []int64, f func(int64) int64) []int64 {
+	result := make([]int64, len(v))
+	for j := range v {
+		result[j] = f(v[j])
+	}
+
+	return result
+}
+
+func BenchmarkIntersect(b *testing.B) {
+	i0 := slices.Clone(unsortedInt64)
+	i1 := slices.Clone(unsortedInt64[0:int(float64(len(unsortedInt64))/1.5)])
+	i2 := slices.Clone(unsortedInt64[len(unsortedInt64)/3:])
+
+	b.Run(fmt.Sprintf("int64_%d-%d-%d_pure", len(i0), len(i1), len(i2)), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = intersectInt64Pure(i0, i1, i2)
+		}
+	})
+
+	b.Run(fmt.Sprintf("int64_%d-%d-%d", len(i0), len(i1), len(i2)), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = slices.Intersection(i0, i1, i2)
+		}
+	})
+
+	b.Run(fmt.Sprintf("int64_%d-%d-%d_hash", len(i0), len(i1), len(i2)), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = slices.IntersectionHash(i0, i1, i2)
+		}
+	})
+}
+
+func intersectInt64Pure(v ...[]int64) []int64 {
+	result := make([]int64, 0, len(v[0]))
+
+	isInSlices := func(t int64, v ...[]int64) bool {
+		n := 0
+		for i := range v {
+			for j := range v[i] {
+				if v[i][j] == t {
+					n++
+					break
+				}
+			}
+
+			if n == i {
+				return false
+			}
+		}
+
+		return n == len(v)
+	}
+	isInSlice := func(t int64, v []int64) bool {
+		for i := range v {
+			if v[i] == t {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	for i := range v {
+		for j := range v[i] {
+			if !isInSlice(v[i][j], result) && isInSlices(v[i][j], v...) {
+				result = append(result, v[i][j])
+			}
+		}
+	}
+
+	return result
+}
+
+func TestBenchmarkPureFuncs(t *testing.T) {
+	t.Run("reverse", func(t *testing.T) {
+		s := []string{"a", "b", "c"}
+		i := []int64{1, 2, 3}
+
+		gotStringsPure := reverseStringsPure(s)
+		gotInt64Pure := reverseInt64sPure(i)
+
+		gotStringsLib := slices.Reverse(s)
+		gotInt64Lib := slices.Reverse(i)
+
+		assertEqual(t, gotStringsLib, gotStringsPure)
+		assertEqual(t, gotInt64Lib, gotInt64Pure)
+	})
+
+	t.Run("concat", func(t *testing.T) {
+		s0 := []string{"a", "b", "c"}
+		s1 := []string{"d", "e", "f"}
+		s2 := []string{"g", "h", "i"}
+
+		i0 := []int64{1, 2, 3}
+		i1 := []int64{4, 5, 6}
+		i2 := []int64{7, 8, 9}
+
+		gotStringsPure := concanStringsPure(s0, s1, s2)
+		gotInt64Pure := concanInt64Pure(i0, i1, i2)
+
+		gotStringsLib := slices.Concat(s0, s1, s2)
+		gotInt64Lib := slices.Concat(i0, i1, i2)
+
+		assertEqual(t, gotStringsLib, gotStringsPure)
+		assertEqual(t, gotInt64Lib, gotInt64Pure)
+	})
+
+	t.Run("filter", func(t *testing.T) {
+		s := []string{"a", "b", "c"}
+		sFunc := func(v string) bool {
+			return v == "a"
+		}
+		i := []int64{1, 2, 3}
+		iFunc := func(v int64) bool {
+			return v == 2
+		}
+
+		gotStringsPure := filterStringsPure(s, sFunc)
+		gotInt64Pure := filterInt64Pure(i, iFunc)
+
+		gotStringsLib := slices.Filter(s, sFunc)
+		gotInt64Lib := slices.Filter(i, iFunc)
+
+		assertEqual(t, gotStringsLib, gotStringsPure)
+		assertEqual(t, gotInt64Lib, gotInt64Pure)
+	})
+
+	t.Run("map", func(t *testing.T) {
+		s := []string{"a", "b", "c"}
+		sFunc := func(v string) string {
+			return v + v
+		}
+		i := []int64{1, 2, 3}
+		iFunc := func(v int64) int64 {
+			return v * v
+		}
+
+		gotStringsPure := mapStringsPure(s, sFunc)
+		gotInt64Pure := mapInt64Pure(i, iFunc)
+
+		gotStringsLib := slices.Map(s, sFunc)
+		gotInt64Lib := slices.Map(i, iFunc)
+
+		assertEqual(t, gotStringsLib, gotStringsPure)
+		assertEqual(t, gotInt64Lib, gotInt64Pure)
+	})
+
+	t.Run("intersect", func(t *testing.T) {
+		i0 := slices.Clone(unsortedInt64)
+		i1 := []int64{1, 3, 79, 72, 27, 57, 5, 4, 30, 61, 60, 9, 67, 40}
+		i2 := []int64{12, 75, 74, 54, 34, 32, 23, 43, 68}
+
+		gotInt64Pure := slices.Sort(intersectInt64Pure(i0, i1, i2))
+
+		gotInt64Lib := slices.Sort(slices.Intersection(i0, i1, i2))
+
+		assertEqual(t, gotInt64Lib, gotInt64Pure)
+	})
+
+}
+
+func assertEqual(t *testing.T, got, want interface{}) {
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("want %v; got %v", want, got)
 	}
 }


### PR DESCRIPTION
Hi!  
I've added more benchmarks and improved performance for some methods.  
Benchmark results without changes were:  
```
goos: darwin
goarch: arm64
pkg: github.com/twharmon/slices
BenchmarkStdLibSortFunc-8   	   98938	     11663 ns/op	    8232 B/op	      11 allocs/op
BenchmarkSortFuncShort-8    	   73940	     13807 ns/op	   16352 B/op	      18 allocs/op
BenchmarkStdLibSort-8       	  118772	      9962 ns/op	    8200 B/op	      10 allocs/op
BenchmarkSortShort-8        	  107100	     10912 ns/op	   16352 B/op	      18 allocs/op
BenchmarkReverse/strings_237_pure-8         	 1987234	       594.0 ns/op	    4096 B/op	       1 allocs/op
BenchmarkReverse/strings_237-8              	    5991	    187634 ns/op	 1238684 B/op	    1878 allocs/op
BenchmarkReverse/strings_7584_pure-8        	   77500	     15337 ns/op	  122880 B/op	       1 allocs/op
BenchmarkReverse/strings_7584-8             	       5	 229619742 ns/op	1780660038 B/op	  113723 allocs/op
BenchmarkReverse/int64_70_pure-8            	14534846	        79.49 ns/op	     576 B/op	       1 allocs/op
BenchmarkReverse/int64_70-8                 	  102580	     11547 ns/op	   55424 B/op	     433 allocs/op
BenchmarkConcat/strings_6x237_pure-8        	  496095	      2189 ns/op	   24576 B/op	       1 allocs/op
BenchmarkConcat/strings_6x237-8             	   47464	     25390 ns/op	  230323 B/op	      59 allocs/op
BenchmarkConcat/int64_6x70_pure-8           	 4193443	       284.0 ns/op	    3456 B/op	       1 allocs/op
BenchmarkConcat/int64_6x70-8                	  317482	      3681 ns/op	   33304 B/op	      49 allocs/op
BenchmarkFilter/strings_237_(len>5)_pure-8  	 1372065	       884.6 ns/op	    4096 B/op	       1 allocs/op
BenchmarkFilter/strings_237_(len>5)-8       	   24979	     47321 ns/op	  261826 B/op	     722 allocs/op
BenchmarkFilter/int64_70_(val>40)_pure-8    	 6286593	       190.3 ns/op	     576 B/op	       1 allocs/op
BenchmarkFilter/int64_70_(val>40)-8         	  219350	      5487 ns/op	   19376 B/op	     218 allocs/op
BenchmarkMap/strings_237_replace_a_b_pure-8 	  223681	      5273 ns/op	    4768 B/op	      99 allocs/op
BenchmarkMap/strings_237_replace_a_b-8      	    5971	    195865 ns/op	 1239359 B/op	    1976 allocs/op
BenchmarkMap/int64_237_*5_pure-8            	 9245161	       128.5 ns/op	     576 B/op	       1 allocs/op
BenchmarkMap/int64_237_*5-8                 	  101328	     11642 ns/op	   55424 B/op	     433 allocs/op
BenchmarkIntersect/int64_70-46-47_pure-8    	  228531	      5262 ns/op	     576 B/op	       1 allocs/op
BenchmarkIntersect/int64_70-46-47-8         	  157063	      7575 ns/op	    6136 B/op	     107 allocs/op
```